### PR TITLE
Fix sdist setup option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         },
         'sdist': {
             'dist_dir': 'dist',
-            'install_scripts': 'zettl/bin',
         },
     }
 )


### PR DESCRIPTION
## Summary
- remove `install_scripts` from sdist options in `setup.py`

## Testing
- `python setup.py sdist --dry-run` *(fails to build due to missing PKG-INFO but no unknown option is reported)*

------
https://chatgpt.com/codex/tasks/task_e_684cb71ab8d08329806bfa69166120b1